### PR TITLE
Test fixes and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ images: ## Build the image 🚀.
 	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:php-5.6 ./php-5.6
 
 test: ## Test the images.
-	${BATS} ./tests/graze_composer_latest.bats
-	${BATS} ./tests/graze_composer_php-7.0.bats
-	${BATS} ./tests/graze_composer_php-5.6.bats
+	${BATS} -t ./tests/graze_composer_latest.bats
+	${BATS} -t ./tests/graze_composer_php-7.0.bats
+	${BATS} -t ./tests/graze_composer_php-5.6.bats
 
 clean: ## Delete any images.
 	${DOCKER} images --quiet graze/composer | xargs ${DOCKER} rmi -f

--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "alpine version is correct" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c 'cat /etc/os-release'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c 'cat /etc/os-release'
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
@@ -9,7 +9,7 @@
 }
 
 @test "composer version is correct" {
-  run docker run --rm graze/composer:php-7.0 --version --no-ansi
+  run docker run --rm graze/composer:latest --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   version="$(echo $output | awk '{ print $3 }')"
@@ -19,7 +19,7 @@
 }
 
 @test "the image has a disk size under 100MB" {
-    run docker images graze/composer:php-7.0
+    run docker images graze/composer:latest
     echo 'status:' $status
     echo 'output:' $output
     size="$(echo ${lines[1]} | awk -F '   *' '{ print int($5) }')"
@@ -28,8 +28,14 @@
     [ $size -lt 100 ]
 }
 
+@test "the composer wrapper has been copied" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/local/bin/composer-wrapper ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image entrypoint should be the composer wrapper" {
-  run bash -c "docker inspect graze/composer:php-7.0 | jq -r '.[]?.Config.Entrypoint[]?'"
+  run bash -c "docker inspect graze/composer:latest | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -37,7 +43,7 @@
 }
 
 @test "the image volumes are correct" {
-  run bash -c "docker inspect graze/composer:php-7.0 | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
+  run bash -c "docker inspect graze/composer:latest | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -46,25 +52,25 @@
 }
 
 @test "the image has git installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/git ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/git ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has mercurial installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/hg ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has svn installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/svn ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/svn ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has the correct php modules installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '/usr/bin/php7 -m'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 -m'
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]

--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -69,6 +69,16 @@
   [ "$status" -eq 0 ]
 }
 
+@test "the image has php 7.0 installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 --version'
+  echo 'status:' $status
+  echo 'output:' $output
+  version="$(echo ${lines[0]} | awk '{ print $2 }')"
+  echo 'version:' $version
+  [ "$status" -eq 0 ]
+  [[ "$version" == 7.0.* ]]
+}
+
 @test "the image has the correct php modules installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 -m'
   echo 'status:' $status

--- a/tests/graze_composer_php-5.6.bats
+++ b/tests/graze_composer_php-5.6.bats
@@ -69,6 +69,16 @@
   [ "$status" -eq 0 ]
 }
 
+@test "the image has php 5.6 installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '/usr/bin/php --version'
+  echo 'status:' $status
+  echo 'output:' $output
+  version="$(echo ${lines[0]} | awk '{ print $2 }')"
+  echo 'version:' $version
+  [ "$status" -eq 0 ]
+  [[ "$version" == 5.6.* ]]
+}
+
 @test "the image has the correct php modules installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '/usr/bin/php -m'
   echo 'status:' $status

--- a/tests/graze_composer_php-5.6.bats
+++ b/tests/graze_composer_php-5.6.bats
@@ -28,6 +28,12 @@
     [ $size -lt 100 ]
 }
 
+@test "the composer wrapper has been copied" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '[ -x /usr/local/bin/composer-wrapper ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image entrypoint should be the composer wrapper" {
   run bash -c "docker inspect graze/composer:php-5.6 | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -69,6 +69,16 @@
   [ "$status" -eq 0 ]
 }
 
+@test "the image has php 7.0 installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 --version'
+  echo 'status:' $status
+  echo 'output:' $output
+  version="$(echo ${lines[0]} | awk '{ print $2 }')"
+  echo 'version:' $version
+  [ "$status" -eq 0 ]
+  [[ "$version" == 7.0.* ]]
+}
+
 @test "the image has the correct php modules installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '/usr/bin/php7 -m'
   echo 'status:' $status

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -28,6 +28,12 @@
     [ $size -lt 100 ]
 }
 
+@test "the composer wrapper has been copied" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/local/bin/composer-wrapper ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image entrypoint should be the composer wrapper" {
   run bash -c "docker inspect graze/composer:php-7.0 | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status


### PR DESCRIPTION
Turns out `graze_composer_latest.bats` was not testing against the `latest` tag.

This PR fixes that, and also adds a test that the wrapper script has been copied and is executable.
