### PR TITLE
Add a check for the bats command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/sh
 DOCKER ?= $(shell which docker)
 DOCKER_REPOSITORY := graze/composer
 
-BATS ?= $(shell which bats)
+BATS := $(shell which bats)
 
 .PHONY: images test clean help
 
@@ -17,6 +17,9 @@ images: ## Build the image 🚀.
 	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:php-5.6 ./php-5.6
 
 test: ## Test the images.
+ifndef BATS
+	$(error "bats not available. Please install it first.")
+endif
 	${BATS} ./tests/graze_composer_latest.bats
 	${BATS} ./tests/graze_composer_php-7.0.bats
 	${BATS} ./tests/graze_composer_php-5.6.bats

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ SHELL = /bin/sh
 DOCKER ?= $(shell which docker)
 DOCKER_REPOSITORY := graze/composer
 
-BATS := $(shell which bats)
+BATS ?= $(shell which bats)
+
+EXECUTABLES = docker bats
+CHECK := $(foreach executable,$(EXECUTABLES),\
+	$(if $(shell which $(executable)),"",$(error "No executable found for $(executable).")))
 
 .PHONY: images test clean help
 
@@ -17,9 +21,6 @@ images: ## Build the image 🚀.
 	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:php-5.6 ./php-5.6
 
 test: ## Test the images.
-ifndef BATS
-	$(error "bats not available. Please install it first.")
-endif
 	${BATS} ./tests/graze_composer_latest.bats
 	${BATS} ./tests/graze_composer_php-7.0.bats
 	${BATS} ./tests/graze_composer_php-5.6.bats


### PR DESCRIPTION
This change adds a check for the `bats` command used during testing.

I did not have it installed on my machine which resulted in the following error:

```
[burhan@callisto docker-composer (master)] {0} $ make -s test
make: ./tests/graze_composer_latest.bats: Permission denied
make: *** [test] Error 1
```

Now if it is not installed, you get this message instead:

```
[burhan@callisto docker-composer (check-bats-exists)] {0} $ make -s test
Makefile:21: *** "bats not available. Please install it first.".  Stop.
```
