### PR TITLE
Use the new Fastly CDN for the testing package repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ CHECK := $(foreach executable,$(EXECUTABLES),\
 default: help
 
 images: ## Build the image 🚀.
-	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:latest ./php-7.0
-	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:php-7.0 ./php-7.0
-	${DOCKER} build --pull -t ${DOCKER_REPOSITORY}:php-5.6 ./php-5.6
+	${DOCKER} build --pull --tag ${DOCKER_REPOSITORY}:latest ./php-7.0
+	${DOCKER} build --pull --tag ${DOCKER_REPOSITORY}:php-7.0 ./php-7.0
+	${DOCKER} build --pull --tag ${DOCKER_REPOSITORY}:php-5.6 ./php-5.6
 
 test: ## Test the images.
 	${BATS} -t ./tests/graze_composer_latest.bats

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:edge
 
 MAINTAINER Samuel Parkinson <sam@graze.com>
 
-RUN echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     apk add --no-cache \
     ca-certificates \
     git \


### PR DESCRIPTION
See https://github.com/gliderlabs/docker-alpine/pull/146.
