### PR TITLE
Create and use a `composer` user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ A _small_ Docker image for [composer](https://getcomposer.org), a dependency man
 ```bash
 ~$ docker run --rm -it \
    -v $(pwd):/usr/src/app \
-   -v ~/.composer:/root/.composer \
-   -v ~/.ssh:/root/.ssh:ro \
+   -v ~/.composer:/home/composer/.composer \
+   -v ~/.ssh:/home/composer/.ssh:ro \
    graze/composer
 ```
 

--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -28,7 +28,11 @@ RUN /usr/bin/wget -qO - https://getcomposer.org/installer | \
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 
-VOLUME ["/usr/src/app", "/root/.composer"]
+RUN adduser -D -S -s /bin/false composer
+
+USER composer
+
+VOLUME ["/usr/src/app", "/home/composer/.composer"]
 
 WORKDIR /usr/src/app
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -28,7 +28,11 @@ RUN /usr/bin/wget -qO - https://getcomposer.org/installer | \
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 
-VOLUME ["/usr/src/app", "/root/.composer"]
+RUN adduser -D -S -s /bin/false composer
+
+USER composer
+
+VOLUME ["/usr/src/app", "/home/composer/.composer"]
 
 WORKDIR /usr/src/app
 

--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -1,7 +1,11 @@
 #!/usr/bin/env bats
 
+setup() {
+  tag=$(basename $(echo $BATS_TEST_FILENAME | cut -d _ -f 3) .bats)
+}
+
 @test "alpine version is correct" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c 'cat /etc/os-release'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c 'cat /etc/os-release'
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
@@ -9,7 +13,7 @@
 }
 
 @test "composer version is correct" {
-  run docker run --rm graze/composer:latest --version --no-ansi
+  run docker run --rm graze/composer:$tag --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -17,7 +21,7 @@
 }
 
 @test "the image has a disk size under 100MB" {
-    run docker images graze/composer:latest
+    run docker images graze/composer:$tag
     echo 'status:' $status
     echo 'output:' $output
     size="$(echo ${lines[1]} | awk -F '   *' '{ print int($5) }')"
@@ -27,13 +31,13 @@
 }
 
 @test "the composer wrapper has been copied" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/local/bin/composer-wrapper ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/local/bin/composer-wrapper ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image entrypoint should be the composer wrapper" {
-  run bash -c "docker inspect graze/composer:latest | jq -r '.[]?.Config.Entrypoint[]?'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -41,34 +45,34 @@
 }
 
 @test "the image volumes are correct" {
-  run bash -c "docker inspect graze/composer:latest | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
   [[ "$output" == *"/usr/src/app"* ]]
-  [[ "$output" == *"/root/.composer"* ]]
+  [[ "$output" == *"/home/composer/.composer"* ]]
 }
 
 @test "the image has git installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/git ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/git ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has mercurial installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/hg ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has svn installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '[ -x /usr/bin/svn ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/svn ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has php 7.0 installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 --version'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '/usr/bin/php7 --version'
   echo 'status:' $status
   echo 'output:' $output
   version="$(echo ${lines[0]} | awk '{ print $2 }')"
@@ -78,7 +82,7 @@
 }
 
 @test "the image has the correct php modules installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:latest -c '/usr/bin/php7 -m'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '/usr/bin/php7 -m'
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -91,7 +95,7 @@
 }
 
 @test "the root user warning isn't displayed by composer" {
-  run docker run --rm -t graze/composer:latest --version --no-ansi
+  run docker run --rm -t graze/composer:$tag --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   [[ "$output" != *"Running composer as root is highly discouraged"* ]]

--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -12,10 +12,8 @@
   run docker run --rm graze/composer:latest --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
-  version="$(echo $output | awk '{ print $3 }')"
-  echo 'version:' $version
   [ "$status" -eq 0 ]
-  [ "$version" = "1.0-dev" ]
+  [[ "$output" == *"1.0-dev"* ]]
 }
 
 @test "the image has a disk size under 100MB" {
@@ -90,4 +88,11 @@
   [[ "${output,,}" == *"openssl"* ]]
   [[ "${output,,}" == *"phar"* ]]
   [[ "${output,,}" == *"posix"* ]]
+}
+
+@test "the root user warning isn't displayed by composer" {
+  run docker run --rm -t graze/composer:latest --version --no-ansi
+  echo 'status:' $status
+  echo 'output:' $output
+  [[ "$output" != *"Running composer as root is highly discouraged"* ]]
 }

--- a/tests/graze_composer_php-5.6.bats
+++ b/tests/graze_composer_php-5.6.bats
@@ -1,7 +1,11 @@
 #!/usr/bin/env bats
 
+setup() {
+  tag=$(basename $(echo $BATS_TEST_FILENAME | cut -d _ -f 3) .bats)
+}
+
 @test "alpine version is correct" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c 'cat /etc/os-release'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c 'cat /etc/os-release'
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
@@ -9,7 +13,7 @@
 }
 
 @test "composer version is correct" {
-  run docker run --rm graze/composer:php-5.6 --version --no-ansi
+  run docker run --rm graze/composer:$tag --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -17,7 +21,7 @@
 }
 
 @test "the image has a disk size under 100MB" {
-    run docker images graze/composer:php-5.6
+    run docker images graze/composer:$tag
     echo 'status:' $status
     echo 'output:' $output
     size="$(echo ${lines[1]} | awk -F '   *' '{ print int($5) }')"
@@ -27,13 +31,13 @@
 }
 
 @test "the composer wrapper has been copied" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '[ -x /usr/local/bin/composer-wrapper ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/local/bin/composer-wrapper ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image entrypoint should be the composer wrapper" {
-  run bash -c "docker inspect graze/composer:php-5.6 | jq -r '.[]?.Config.Entrypoint[]?'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -41,34 +45,34 @@
 }
 
 @test "the image volumes are correct" {
-  run bash -c "docker inspect graze/composer:php-5.6 | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
   [[ "$output" == *"/usr/src/app"* ]]
-  [[ "$output" == *"/root/.composer"* ]]
+  [[ "$output" == *"/home/composer/.composer"* ]]
 }
 
 @test "the image has git installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '[ -x /usr/bin/git ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/git ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has mercurial installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '[ -x /usr/bin/hg ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has svn installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '[ -x /usr/bin/svn ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/svn ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has php 5.6 installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '/usr/bin/php --version'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '/usr/bin/php --version'
   echo 'status:' $status
   echo 'output:' $output
   version="$(echo ${lines[0]} | awk '{ print $2 }')"
@@ -78,7 +82,7 @@
 }
 
 @test "the image has the correct php modules installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-5.6 -c '/usr/bin/php -m'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '/usr/bin/php -m'
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -91,7 +95,7 @@
 }
 
 @test "the root user warning isn't displayed by composer" {
-  run docker run --rm -t graze/composer:latest --version --no-ansi
+  run docker run --rm -t graze/composer:$tag --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   [[ "$output" != *"Running composer as root is highly discouraged"* ]]

--- a/tests/graze_composer_php-5.6.bats
+++ b/tests/graze_composer_php-5.6.bats
@@ -12,10 +12,8 @@
   run docker run --rm graze/composer:php-5.6 --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
-  version="$(echo $output | awk '{ print $3 }')"
-  echo 'version:' $version
   [ "$status" -eq 0 ]
-  [ "$version" = "1.0-dev" ]
+  [[ "$output" == *"1.0-dev"* ]]
 }
 
 @test "the image has a disk size under 100MB" {
@@ -90,4 +88,11 @@
   [[ "${output,,}" == *"openssl"* ]]
   [[ "${output,,}" == *"phar"* ]]
   [[ "${output,,}" == *"posix"* ]]
+}
+
+@test "the root user warning isn't displayed by composer" {
+  run docker run --rm -t graze/composer:latest --version --no-ansi
+  echo 'status:' $status
+  echo 'output:' $output
+  [[ "$output" != *"Running composer as root is highly discouraged"* ]]
 }

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -1,7 +1,11 @@
 #!/usr/bin/env bats
 
+setup() {
+  tag=$(basename $(echo $BATS_TEST_FILENAME | cut -d _ -f 3) .bats)
+}
+
 @test "alpine version is correct" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c 'cat /etc/os-release'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c 'cat /etc/os-release'
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
@@ -9,7 +13,7 @@
 }
 
 @test "composer version is correct" {
-  run docker run --rm graze/composer:php-7.0 --version --no-ansi
+  run docker run --rm graze/composer:$tag --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -17,7 +21,7 @@
 }
 
 @test "the image has a disk size under 100MB" {
-    run docker images graze/composer:php-7.0
+    run docker images graze/composer:$tag
     echo 'status:' $status
     echo 'output:' $output
     size="$(echo ${lines[1]} | awk -F '   *' '{ print int($5) }')"
@@ -27,13 +31,13 @@
 }
 
 @test "the composer wrapper has been copied" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/local/bin/composer-wrapper ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/local/bin/composer-wrapper ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image entrypoint should be the composer wrapper" {
-  run bash -c "docker inspect graze/composer:php-7.0 | jq -r '.[]?.Config.Entrypoint[]?'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '.[]?.Config.Entrypoint[]?'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
@@ -41,28 +45,28 @@
 }
 
 @test "the image volumes are correct" {
-  run bash -c "docker inspect graze/composer:php-7.0 | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
+  run bash -c "docker inspect graze/composer:$tag | jq -r '@sh \"\(.[]?.Config.Volumes | to_entries | map(.key))\"'"
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
   [[ "$output" == *"/usr/src/app"* ]]
-  [[ "$output" == *"/root/.composer"* ]]
+  [[ "$output" == *"/home/composer/.composer"* ]]
 }
 
 @test "the image has git installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/git ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/git ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has mercurial installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/hg ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
 
 @test "the image has svn installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '[ -x /usr/bin/svn ]'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/svn ]'
   echo 'status:' $status
   [ "$status" -eq 0 ]
 }
@@ -78,7 +82,7 @@
 }
 
 @test "the image has the correct php modules installed" {
-  run docker run --rm --entrypoint=/bin/sh graze/composer:php-7.0 -c '/usr/bin/php7 -m'
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '/usr/bin/php7 -m'
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -12,10 +12,8 @@
   run docker run --rm graze/composer:php-7.0 --version --no-ansi
   echo 'status:' $status
   echo 'output:' $output
-  version="$(echo $output | awk '{ print $3 }')"
-  echo 'version:' $version
   [ "$status" -eq 0 ]
-  [ "$version" = "1.0-dev" ]
+  [[ "$output" == *"1.0-dev"* ]]
 }
 
 @test "the image has a disk size under 100MB" {
@@ -90,4 +88,11 @@
   [[ "${output,,}" == *"openssl"* ]]
   [[ "${output,,}" == *"phar"* ]]
   [[ "${output,,}" == *"posix"* ]]
+}
+
+@test "the root user warning isn't displayed by composer" {
+  run docker run --rm -t graze/composer:latest --version --no-ansi
+  echo 'status:' $status
+  echo 'output:' $output
+  [[ "$output" != *"Running composer as root is highly discouraged"* ]]
 }


### PR DESCRIPTION
This resolves #16.

I looked up how to best create a user under Alpine Linux from https://support.tutum.co/support/solutions/articles/5000642762-base-alpine. It could explain the `adduser` argument usage a bit more, but I think it's down to the following:
- `-D` the user doesn't need a password
- `-S` it needs to be a _system_ user (not sure what that means)
- `-s /bin/false` the user doesn't need a shell
