### PR TITLE
Use the `--snapshot` argument when installing Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ deploy:
     script: curl --head --request POST "https://registry.hub.docker.com/u/graze/composer/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/"
     on:
       branch: master
-      condition: -n "$CI_NIGHTLY_BUILD"
 
 env:
   global:

--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
     php-posix
 
 RUN /usr/bin/wget -qO - https://getcomposer.org/installer | \
-    /usr/bin/php -- --install-dir=/usr/local/bin --filename=composer
+    /usr/bin/php -- --install-dir /usr/local/bin --filename composer --snapshot
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/t
     php7-posix
 
 RUN /usr/bin/wget -qO - https://getcomposer.org/installer | \
-    /usr/bin/php7 -- --install-dir=/usr/local/bin --filename=composer
+    /usr/bin/php7 -- --install-dir /usr/local/bin --filename composer --snapshot
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 


### PR DESCRIPTION
This should also get the nightly build working on Travis CI as of https://github.com/graze/docker-composer/pull/20/commits/b9b843dec4bb6fdb7f00038700653687830031c3.
