### PR TITLE
Update example usage

### DIFF
--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -3,7 +3,7 @@
 #
 # docker run --rm -it \
 #    -v $(pwd):/usr/src/app \
-#    -v ~/.composer:/root/.composer \
+#    -v ~/.composer:/home/composer/.composer \
 #    -v ~/.ssh:/root/.ssh:ro \
 #    graze/composer:php-5.6
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -3,7 +3,7 @@
 #
 # docker run --rm -it \
 #    -v $(pwd):/usr/src/app \
-#    -v ~/.composer:/root/.composer \
+#    -v ~/.composer:/home/composer/.composer \
 #    -v ~/.ssh:/root/.ssh:ro \
 #    graze/composer:php-7.0
 


### PR DESCRIPTION
Using the old example with the new composer user meant you were left with a
"/home/composer/.composer" directory owned by root and so the composer
couldn't be run correctly.
