### PR TITLE
Install the missing ssh package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ A _small_ Docker image for [composer](https://getcomposer.org), a dependency man
 
 ```bash
 ~$ docker run --rm -it \
-   -v $(pwd):/usr/src/app \
-   -v ~/.composer:/home/composer/.composer \
-   -v ~/.ssh:/home/composer/.ssh:ro \
+    -v $(pwd):/usr/src/app \
+    -v ~/.composer:/home/composer/.composer \
+    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
    graze/composer
 ```
 

--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -4,7 +4,7 @@
 # docker run --rm -it \
 #    -v $(pwd):/usr/src/app \
 #    -v ~/.composer:/home/composer/.composer \
-#    -v ~/.ssh:/root/.ssh:ro \
+#    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
 #    graze/composer:php-5.6
 
 FROM alpine:3.3
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
     ca-certificates \
     git \
     mercurial \
+    openssh \
     subversion \
     php-cli \
     php-curl \
@@ -26,11 +27,13 @@ RUN apk add --no-cache \
 
 RUN php -r "readfile('https://getcomposer.org/installer');" | \
     php -- --install-dir /usr/local/bin --filename composer && \
-    mkdir -p /home/composer/.composer
+    mkdir -p /home/composer/.composer && \
+    ln -s /root/.ssh /home/composer/.ssh
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 
-ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_HOME=/home/composer/.composer
 
 WORKDIR /usr/src/app
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -4,7 +4,7 @@
 # docker run --rm -it \
 #    -v $(pwd):/usr/src/app \
 #    -v ~/.composer:/home/composer/.composer \
-#    -v ~/.ssh:/root/.ssh:ro \
+#    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
 #    graze/composer:php-7.0
 
 FROM alpine:edge
@@ -15,6 +15,7 @@ RUN apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/t
     ca-certificates \
     git \
     mercurial \
+    openssh \
     subversion \
     php7 \
     php7-curl \
@@ -26,11 +27,13 @@ RUN apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/t
 
 RUN php7 -r "readfile('https://getcomposer.org/installer');" | \
     php7 -- --install-dir /usr/local/bin --filename composer && \
-    mkdir -p /home/composer/.composer
+    mkdir -p /home/composer/.composer && \
+    ln -s /root/.ssh /home/composer/.ssh
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 
-ENV COMPOSER_ALLOW_SUPERUSER=1
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_HOME=/home/composer/.composer
 
 WORKDIR /usr/src/app
 

--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -59,6 +59,12 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "the image has openssh installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/ssh ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image has mercurial installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status

--- a/tests/graze_composer_php-5.6.bats
+++ b/tests/graze_composer_php-5.6.bats
@@ -59,6 +59,12 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "the image has openssh installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/ssh ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image has mercurial installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -59,6 +59,12 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "the image has openssh installed" {
+  run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/ssh ]'
+  echo 'status:' $status
+  [ "$status" -eq 0 ]
+}
+
 @test "the image has mercurial installed" {
   run docker run --rm --entrypoint=/bin/sh graze/composer:$tag -c '[ -x /usr/bin/hg ]'
   echo 'status:' $status


### PR DESCRIPTION
In testing the last change I found that git was unable to clone repo's over ssh, as the package wasn't installed 😵 .

We only also need the private key mounted, having the config too means more fiddly volume mounting permissions, best avoided.

I've used a symlink on the .ssh folder too, to keep everything under /home/composer.
