### PR TITLE
Update tests after the latest Alpine Linux release

### DIFF
--- a/tests/graze_composer_latest.bats
+++ b/tests/graze_composer_latest.bats
@@ -15,7 +15,7 @@ teardown() {
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
-  [[ "${lines[2]}" == 'VERSION_ID=3.3.0' ]]
+  [[ "${lines[2]}" == "VERSION_ID=3.4."* ]]
 }
 
 @test "composer version is correct" {

--- a/tests/graze_composer_php-7.0.bats
+++ b/tests/graze_composer_php-7.0.bats
@@ -15,7 +15,7 @@ teardown() {
   echo 'status:' $status
   echo 'output:' $output
   [ $status -eq 0 ]
-  [[ "${lines[2]}" == 'VERSION_ID=3.3.0' ]]
+  [[ "${lines[2]}" == "VERSION_ID=3.4."* ]]
 }
 
 @test "composer version is correct" {


### PR DESCRIPTION
Version 3.4.0 was release recently, so our latest image should be using that.
