### PR TITLE
Fix 7.0 builds

### DIFF
--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -35,8 +35,6 @@ RUN apk add --no-cache \
     php7-posix \
     php7-zlib
 
-RUN ln -s /usr/bin/php7 /usr/bin/php
-
 ARG COMPOSER_VER
 ENV COMPOSER_VER ${COMPOSER_VER:-1.4.1}
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -47,6 +47,8 @@ LABEL org.label-schema.version="${COMPOSER_VER}-php7.0"
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
 
+RUN ln -s /usr/bin/php7 /usr/bin/php
+
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /home/composer/.composer
 

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -7,7 +7,7 @@
 #    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
 #    graze/composer:php-7.0
 
-FROM alpine:edge
+FROM alpine:3.5
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -35,6 +35,8 @@ RUN apk add --no-cache \
     php7-posix \
     php7-zlib
 
+RUN ln -s /usr/bin/php7 /usr/bin/php
+
 ARG COMPOSER_VER
 ENV COMPOSER_VER ${COMPOSER_VER:-1.4.1}
 
@@ -46,8 +48,6 @@ RUN php -r "readfile('https://getcomposer.org/installer');" | \
 LABEL org.label-schema.version="${COMPOSER_VER}-php7.0"
 
 COPY ./composer-wrapper /usr/local/bin/composer-wrapper
-
-RUN ln -s /usr/bin/php7 /usr/bin/php
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /home/composer/.composer

--- a/php-7.1/Dockerfile
+++ b/php-7.1/Dockerfile
@@ -17,7 +17,7 @@ LABEL maintainer="developers@graze.com" \
     org.label-schema.description="alpine composer image" \
     org.label-schema.vcs-url="https://github.com/graze/docker-composer"
 
-RUN apk add --no-cache --repository "http://dl-cdn.alpinelinux.org/alpine/edge/testing" \
+RUN apk add --no-cache \
     ca-certificates \
     git \
     mercurial \


### PR DESCRIPTION
**Issue**

PHP7.0 builds failing

**Fix**

alpine changed their php7 version in edge to 7.1. Switching alpine version to 3.5 to get the correct version. Also removing testing repository from 7.1 Dockerfile as its not needed anymore
