### PR TITLE
support alpine 3.6

### DIFF
--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -7,7 +7,7 @@
 #    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
 #    graze/composer:php-5.6
 
-FROM alpine:3.5
+FROM alpine:3.6
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \
@@ -33,6 +33,8 @@ RUN apk add --no-cache \
     php5-phar \
     php5-posix \
     php5-zlib
+
+RUN ln -s /usr/bin/php5 /usr/bin/php
 
 ARG COMPOSER_VER
 ENV COMPOSER_VER ${COMPOSER_VER:-1.4.1}

--- a/php-7.1/Dockerfile
+++ b/php-7.1/Dockerfile
@@ -7,7 +7,7 @@
 #    -v ~/.ssh/id_rsa:/home/composer/.ssh/id_rsa:ro \
 #    graze/composer:php-7.1
 
-FROM alpine:edge
+FROM alpine:3.6
 
 LABEL maintainer="developers@graze.com" \
     license="MIT" \

--- a/tests/graze_composer_env.bats
+++ b/tests/graze_composer_env.bats
@@ -32,7 +32,7 @@ teardown() {
   echo 'status:' $status
   echo 'output:' $output
   [ "$status" -eq 0 ]
-  [[ "${lines[2]}" == "VERSION_ID=3.5."* ]]
+  [[ "${lines[2]}" == "VERSION_ID=3."[56]"."* ]]
 }
 
 @test "composer version is correct" {


### PR DESCRIPTION
alpine 3.6 has been released. This fixes things

* updates php5 and php7.1 images to 3.6 (7.0 is still 3.5 because of common package names)