### PR TITLE
add common extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
     # DOCKER_PASSWORD
     - secure: U4Q9BYG1Fco0/uPcUxHIRps6gT07sR1t3zt5+wTf4XmROVOaZWHUtTi6WdgiEgXF0n5TuzN/Vs9QYc4jkvU8r5pV7v6rBLKNtH4jUIidR537SzeffoShXnIPX/XHhb09eobk8Sb/fq5GbZidqsHk5IZlJv60qxvqigJ/m1RrgR6ol74v92WsHrOAB9W+d4LzcD58Uj0YCCW0TOyiWph7B+G8M4ecHRWY/sCEAIAMYcpbQ6LbqsLGe36KH2rctbT+D15qjmuDgj9xN3++F+E9seB6UY4rWQBYH64hC5d8WjqHPhksBZORCj3WFtiKwwBodLLsKvbfMIwTfkpWw2GUS7KIU48TWGEh70qs/LQY+CEV1eFiNenUQ4qik3BAI7GYrrIHZSigqxg2NbVaqdm5Dm3gyc32ANffvnDboQqyX8J4R61rC1no5G7+85plV8LKLszx/ykCh4kf0Lqh4LM+O9pYp6V6bE+hnWE53RhMNo88d1ypnG5Ha0mekfM8qkborytKmJijTjjCCsQ28R2jrJcQqJ3Gt7mskrmSw7TZcKIZrgX+nd7qiY7E4RqHp+uSloDg7DohhKj44jzRYcN4blrA0y/jpeWmSinpK0EDYgdURD94uvWsr93kzGFsGrE+i8x2WpzuATsLPn5jiCCUtFqgJdsCNiDTKs80MRZlDsY=
 script:
-  - make build
+  - travis_retry make build
   - make test
 
 deploy:

--- a/php-5.6/Dockerfile
+++ b/php-5.6/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
     php5-cli \
     php5-ctype \
     php5-curl \
+    php5-dom \
     php5-iconv \
     php5-json \
     php5-openssl \

--- a/php-7.0/Dockerfile
+++ b/php-7.0/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache \
     php7-bz2 \
     php7-ctype \
     php7-curl \
+    php7-dom \
     php7-iconv \
     php7-json \
     php7-mbstring \

--- a/php-7.1/Dockerfile
+++ b/php-7.1/Dockerfile
@@ -27,12 +27,16 @@ RUN apk add --no-cache \
     php7-bz2 \
     php7-ctype \
     php7-curl \
+    php7-dom \
     php7-iconv \
     php7-json \
     php7-mbstring \
     php7-openssl \
     php7-phar \
     php7-posix \
+    php7-simplexml \
+    php7-tokenizer \
+    php7-xmlwriter \
     php7-zlib
 
 ARG COMPOSER_VER

--- a/tests/graze_composer_env.bats
+++ b/tests/graze_composer_env.bats
@@ -190,10 +190,14 @@ teardown() {
   [[ "${output}" == *"bz2"* ]]
   [[ "${output}" == *"ctype"* ]]
   [[ "${output}" == *"curl"* ]]
+  [[ "${output}" == *"dom"* ]]
   [[ "${output}" == *"json"* ]]
   [[ "${output}" == *"openssl"* ]]
   [[ "${output}" == *"Phar"* ]]
   [[ "${output}" == *"posix"* ]]
+  [[ "${output}" == *"SimpleXML"* ]]
+  [[ "${output}" == *"tokenizer"* ]]
+  [[ "${output}" == *"xmlwriter"* ]]
   [[ "${output}" == *"zlib"* ]]
 }
 


### PR DESCRIPTION
Add some common extensions to reduce the likelyhood of `{config: platform: ext-bla: 1}` being required.

Is it sensible to add them in here, or should each app specify the `config: platform` stuff, and by hiding we are just deferring the problem?